### PR TITLE
For redmine 3131. Port number option moved to cyREST.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,10 @@
 		<bundle.symbolicName>org.cytoscape.rest.cy-rest</bundle.symbolicName>
 		<bundle.namespace>org.cytoscape.rest</bundle.namespace>
 		<maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+		<maven-bundle-plugin.version>2.5.4</maven-bundle-plugin.version>
 		<osgi.api.version>4.2.0</osgi.api.version>
 		<junit.version>4.12</junit.version>
-		<jersey.version>2.19</jersey.version>
+		<jersey.version>2.21</jersey.version>
 
 		<rest.api.version>v1</rest.api.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,7 +18,7 @@
 
 	<groupId>org.cytoscape</groupId>
 	<artifactId>cy-rest</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>bundle</packaging>
 	<name>cyREST</name>
 
@@ -79,7 +80,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>${maven-bundle-plugin.version}</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
@@ -98,7 +99,7 @@
 			<plugin>
 				<groupId>com.qmino</groupId>
 				<artifactId>miredot-plugin</artifactId>
-				<version>1.6.1</version>
+				<version>1.6.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -272,7 +273,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.6.0</version>
+			<version>2.6.1</version>
 		</dependency>
 
 		<!-- Jersey -->

--- a/src/main/java/org/cytoscape/rest/internal/CyActivator.java
+++ b/src/main/java/org/cytoscape/rest/internal/CyActivator.java
@@ -122,6 +122,20 @@ public class CyActivator extends AbstractCyActivator {
 		final AvailableCommands available = getService(bc, AvailableCommands.class);
 		final CommandExecutorTaskFactory ceTaskFactory = getService(bc, CommandExecutorTaskFactory.class);
 		final SynchronousTaskManager<?> synchronousTaskManager = getService(bc, SynchronousTaskManager.class);
+		
+		// Get any command line arguments. The "-R" is ours
+		@SuppressWarnings("unchecked")
+		final CyProperty<Properties> commandLineProps = getService(bc, CyProperty.class, "(cyPropertyName=commandline.props)");
+
+		final Properties clProps = commandLineProps.getProperties();
+		
+		String restPortNumber = cyPropertyServiceRef.getProperties().getProperty(GrizzlyServerManager.PORT_NUMBER_PROP);
+		
+		if (clProps.getProperty(GrizzlyServerManager.PORT_NUMBER_PROP) != null)
+			restPortNumber = clProps.getProperty(GrizzlyServerManager.PORT_NUMBER_PROP);
+		
+		// Set Port number
+		cyPropertyServiceRef.getProperties().setProperty(GrizzlyServerManager.PORT_NUMBER_PROP, restPortNumber);
 
 		// Task factories
 		final NewNetworkSelectedNodesAndEdgesTaskFactory networkSelectedNodesAndEdgesTaskFactory = getService(bc,

--- a/src/main/java/org/cytoscape/rest/internal/task/GrizzlyServerManager.java
+++ b/src/main/java/org/cytoscape/rest/internal/task/GrizzlyServerManager.java
@@ -36,8 +36,9 @@ public final class GrizzlyServerManager {
 
 	private final static Logger logger = LoggerFactory.getLogger(GrizzlyServerManager.class);
 
+	public static final String PORT_NUMBER_PROP = "rest.port";
+	
 	private String baseURL = "http://0.0.0.0";
-	private String PORT_NUMBER_PROP = "rest.port";
 	private Integer DEF_PORT_NUMBER = 1234;
 	private Integer portNumber = DEF_PORT_NUMBER;
 


### PR DESCRIPTION
Port number options are managed by cyREST, instead of rest-impl.