### PR TITLE
Updates the free Miredot license to an open-source license.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 				</executions>
 				<configuration>
 					<licence>
-						UHJvamVjdHxvcmcuY3l0b3NjYXBlLmN5LXJlc3R8MjAxOS0wOC0xMnx0cnVlI01Dd0NGQzZwaksydUc5QlJ5TFFMczlWQjJmOWRLNytKQWhRVWU5U3NqaHRXK3B6WW5kQjd5VUZBWGc1R0VnPT0=
+						cHJvamVjdHxvcmcuY3l0b3NjYXBlLmN5LXJlc3R8MjAxOC0wOC0xMnx0cnVlfC0xI01Dd0NGQ2VZWng4T1k3WHl6QVZ6emNqQ3V6czIwOWZEQWhSalVwcjN0MEJ4SFlobkt4elF6TkdHbkZldlNBPT0=
 					</licence>
 					<!-- insert other configuration here (optional) -->
 					<output>


### PR DESCRIPTION
Dear maintainers of cyREST,

We noticed you were using a free Miredot license for your open-source Cytoscape app. We thought we'd help you out and upgrade that license to an open-source license.

With this license you get access to all the paying features, free of charge. If you have any questions or problems, please let us know!

Kind Regards,

Ewout & The Miredot team.

P.S.: I couldn't build the project with Maven due to not having access to all dependencies, so I couldn't verify if everything was in order.